### PR TITLE
FIX: Indexing

### DIFF
--- a/badbaby/processing/badbaby.yml
+++ b/badbaby/processing/badbaby.yml
@@ -487,7 +487,7 @@ epoching:
       [-1, -1, -1, 1, -1, -1, -1, -1, -1],
       [-1, -1, -1, -1, 1, 2, 3, 4, 5],
     ]
-  must_match: [[], [0, 1, 2], [0, 1], [], []]  # 0-based indices, not numbers
+  must_match: [[], [0, 1, 2], [0, 1, 2], [], []]  # 0-based indices
 
 covariance:
   cov_method: shrunk

--- a/badbaby/processing/badbaby.yml
+++ b/badbaby/processing/badbaby.yml
@@ -123,9 +123,9 @@ scoring:
 
 preprocessing:
   multithreading:
-    n_jobs: 4
-    n_jobs_fir: 4
-    n_jobs_resample: 4
+    n_jobs: "cuda"
+    n_jobs_fir: "cuda"
+    n_jobs_resample: "cuda"
   bads:
     mf_prebad:
       {
@@ -487,7 +487,7 @@ epoching:
       [-1, -1, -1, 1, -1, -1, -1, -1, -1],
       [-1, -1, -1, -1, 1, 2, 3, 4, 5],
     ]
-  must_match: [[], [0, 1, 2], [0, 1, 2], [], []]  # 0-based indices
+  must_match: [[], [0, 1, 2], [0, 1], [], []]  # 0-based indices
 
 covariance:
   cov_method: shrunk
@@ -504,10 +504,9 @@ report:
   whitening: [{ analysis: All, name: All }]
   sensor:
     [
-      { analysis: All, name: All, times: "peaks", proj: False },
-      { analysis: All, name: All, times: "peaks" },
-      { analysis: All, name: All, times: "peaks", proj: "reconstruct" },
-      { analysis: Oddball, name: standard, times: "peaks" },
-      { analysis: Oddball, name: deviant, times: "peaks" },
-      { analysis: AM, name: tone, times: "peaks" },
+      { analysis: All, name: All, times: "peaks", proj: False},
+      { analysis: All, name: All, times: "peaks", proj: "reconstruct"},
+      { analysis: Oddball, name: standard, times: "peaks", proj: "reconstruct"},
+      { analysis: Oddball, name: deviant, times: "peaks", proj: "reconstruct"},
+      { analysis: AM, name: tone, times: "peaks", proj: "reconstruct"},
     ]

--- a/badbaby/processing/badbaby.yml
+++ b/badbaby/processing/badbaby.yml
@@ -487,7 +487,7 @@ epoching:
       [-1, -1, -1, 1, -1, -1, -1, -1, -1],
       [-1, -1, -1, -1, 1, 2, 3, 4, 5],
     ]
-  must_match: [[], [1, 2, 3], [1, 2], [], []]
+  must_match: [[], [0, 1, 2], [0, 1], [], []]  # 0-based indices, not numbers
 
 covariance:
   cov_method: shrunk

--- a/badbaby/processing/run_mnefun.py
+++ b/badbaby/processing/run_mnefun.py
@@ -80,9 +80,20 @@ params.score = score
 # Set what will run
 good, bad = list(), list()
 use_subjects = params.subjects
-# use_subjects = ['bad_130a', 'bad_225b', 'bad_226b']
+# use_subjects = use_subjects[use_subjects.index('bad_209a'):][:1]
 
-continue_on_error = False
+# Still need to fix:
+# use_subjects = ['bad_105']  # RuntimeError: Only 5/1262 good ECG epochs found
+# use_subjects = ['bad_116a']  # evoked[0].info['meas_id'] is not None / IndexError: list index out of range
+# use_subjects = ['bad_130a']  # no good epochs for ERM SSP
+# use_subjects = ['bad_225b']  # no good epochs for ERM SSP
+# use_subjects = ['bad_226b']  # no good epochs for ERM SSP
+# use_subjects = ['bad_302a']  # Expected 2 ERM projectors for channel type grad based on proj_nums but got 0 in /mnt/bakraid/larsoner/kam/badbaby/badbaby/data/bad_302a/sss_pca_fif/preproc_cont-proj.fif
+# use_subjects = ['bad_310b']  # RuntimeError: Only 7/1527 good ECG epochs found
+# use_subjects = ['bad_925b']  # ValueError: extended_proj[0] channel names (length 299) do not match the good MEG channel names (length 297)
+# Re-run epoching/cov/report for all to make sure no events are missing.
+
+continue_on_error = True
 for subject in use_subjects:
     params.subject_indices = [params.subjects.index(subject)]
     default = False

--- a/badbaby/processing/run_mnefun.py
+++ b/badbaby/processing/run_mnefun.py
@@ -79,8 +79,8 @@ params.score = score
 
 # Set what will run
 good, bad = list(), list()
-use_subjects = params.subjects
-# use_subjects = use_subjects[use_subjects.index('bad_209a'):][:1]
+# use_subjects = params.subjects
+use_subjects = ['bad_925b']
 
 # Still need to fix:
 # use_subjects = ['bad_105']  # RuntimeError: Only 5/1262 good ECG epochs found
@@ -93,7 +93,7 @@ use_subjects = params.subjects
 # use_subjects = ['bad_925b']  # ValueError: extended_proj[0] channel names (length 299) do not match the good MEG channel names (length 297)
 # Re-run epoching/cov/report for all to make sure no events are missing.
 
-continue_on_error = True
+continue_on_error = False
 for subject in use_subjects:
     params.subject_indices = [params.subjects.index(subject)]
     default = False
@@ -101,16 +101,14 @@ for subject in use_subjects:
         mnefun.do_processing(
             params,
             fetch_raw=default,
-            do_score=True,
-            push_raw=default,
-            do_sss=True,
-            fetch_sss=default,
-            do_ch_fix=True,
-            gen_ssp=True,
-            apply_ssp=True,
+            do_score=default,
+            do_sss=default,
+            do_ch_fix=default,
+            gen_ssp=default,
+            apply_ssp=default,
             write_epochs=True,
-            gen_covs=True,
-            gen_report=True,
+            gen_covs=default,
+            gen_report=default,
             print_status=default,
         )
     except Exception:

--- a/badbaby/processing/run_mnefun.py
+++ b/badbaby/processing/run_mnefun.py
@@ -8,8 +8,13 @@ runs were 104, 114 , 120b, 127b, 130a, 203, 209a, 213 , 217	bad_231b, 304a,
 921a. Files were uploaded to /data06/larsoner/for_hank/brainstudio with
 variants of:
 
-$ rsync -a --rsh="ssh -o KexAlgorithms=diffie-hellman-group1-sha1" --partial --progress --include="*_raw.fif" --include="*_raw-1.fif" --exclude="*" /media/ktavabi/ALAYA/data/ilabs/badbaby/*/bad_114/raw_fif/* larsoner@kasga.ilabs.uw.edu:/data06/larsoner/for_hank/brainstudio
->>> mne.io.read_raw_fif('../mismatch/bad_114/raw_fif/bad_114_mmn_raw.fif', allow_maxshield='yes').info['meas_date'].strftime('%y%m%d')
+$ rsync -a --rsh="ssh -o KexAlgorithms=diffie-hellman-group1-sha1"
+--partial --progress --include="*_raw.fif" --include="*_raw-1.fif"
+--exclude="*" /media/ktavabi/ALAYA/data/ilabs/badbaby/*/bad_114/raw_fif/*
+larsoner@kasga.ilabs.uw.edu:/data06/larsoner/for_hank/brainstudio
+
+$ mne.io.read_raw_fif('../mismatch/bad_114/raw_fif/bad_114_mmn_raw.fif',
+allow_maxshield='yes').info['meas_date'].strftime('%y%m%d')
 
 Then repackaged manually into brainstudio/bad_baby/bad_*/*/ directories
 based on the recording dates (or just using 111111 for simplicity).
@@ -80,7 +85,7 @@ params.score = score
 # Set what will run
 good, bad = list(), list()
 # use_subjects = params.subjects
-use_subjects = ['bad_925b']
+use_subjects = ["bad_310b"]
 
 # Still need to fix:
 # use_subjects = ['bad_105']  # RuntimeError: Only 5/1262 good ECG epochs found
@@ -108,8 +113,8 @@ for subject in use_subjects:
             apply_ssp=default,
             write_epochs=True,
             gen_covs=default,
-            gen_report=default,
-            print_status=default,
+            gen_report=True,
+            print_status=True,
         )
     except Exception:
         if not continue_on_error:
@@ -118,5 +123,4 @@ for subject in use_subjects:
         bad.append(subject)
     else:
         good.append(subject)
-print(
-    f"Successfully processed {len(good)}/{len(good) + len(bad)}, bad:\n{bad}")
+print(f"Successfully processed {len(good)}/{len(good) + len(bad)}, bad:\n{bad}")


### PR DESCRIPTION
Closes #13

Needs https://github.com/LABSN/mnefun/pull/339

On these two branches I see:
```
Doing epoch EQ/DQ. 
  Loading raw files for subject bad_925b.
    Epoching data (decim=5 -> sfreq=360.0 Hz).
    Computing autoreject thresholds: grad=3926 fT/cm
    Events restricted to those in params.in_numbers
    Matching trial counts and saving data to disk.
      Analysis "All": 432 epochs / condition
        Equalizing: ['std', 'ba', 'wa']
      Analysis "Individual": 19 epochs / condition
        Equalizing: ['std', 'ba']
      Analysis "Oddball": 27, 46 epochs / condition
      Analysis "AM": 107 epochs / condition
        Got 0 epochs for: ['s3', 's5']
      Analysis "IDs": 0, 1 epochs / condition
    Saving epochs to disk.
  (0:00:21.869)
Done
Successfully processed 1/1, bad:
[]

```
I also delete `push_raw` and `fetch_sss` steps since they should never need to be run (it's just used for remote MaxFilter steps, which this pipeline doesn't use)