### PR TITLE
BUG: Fix match_fun assignment

### DIFF
--- a/badbaby/processing/badbaby.yml
+++ b/badbaby/processing/badbaby.yml
@@ -487,7 +487,7 @@ epoching:
       [-1, -1, -1, 1, -1, -1, -1, -1, -1],
       [-1, -1, -1, -1, 1, 2, 3, 4, 5],
     ]
-  must_match: [[], [0, 1, 2], [0, 1], [], []]  # 0-based indices
+  must_match: [[], [0, 1, 2], [0, 1, 2], [], []]  # 0-based indices
 
 covariance:
   cov_method: shrunk

--- a/badbaby/processing/run_mnefun.py
+++ b/badbaby/processing/run_mnefun.py
@@ -34,7 +34,7 @@ import janitor  # noqa
 import mnefun
 import pandas as pd
 
-from score import score
+from score import score, eq_trials
 
 static = op.join(Path(__file__).parents[1], "static")
 
@@ -81,16 +81,12 @@ params = mnefun.read_params(
 params.work_dir = "/media/ktavabi/ALAYA/data/ilabs/badbaby"
 params.ecg_channel = ecg_channel
 params.score = score
+params.match_fun = eq_trials
 
 # Set what will run
 good, bad = list(), list()
-<<<<<<< HEAD
 # use_subjects = params.subjects
 use_subjects = ["bad_310b"]
-=======
-use_subjects = params.subjects
-# use_subjects = ['bad_925b']
->>>>>>> 4a1b62d1876a87c54bb18097046bc143b4c6a3d5
 
 # Still need to fix:
 # use_subjects = ['bad_105']  # RuntimeError: Only 5/1262 good ECG epochs found
@@ -111,15 +107,15 @@ for subject in use_subjects:
         mnefun.do_processing(
             params,
             fetch_raw=default,
-            do_score=True,
-            do_sss=True,
+            do_score=default,
+            do_sss=default,
             do_ch_fix=default,
-            gen_ssp=True,
-            apply_ssp=True,
+            gen_ssp=default,
+            apply_ssp=default,
             write_epochs=True,
             gen_covs=default,
-            gen_report=True,
-            print_status=True,
+            gen_report=default,
+            print_status=default,
         )
     except Exception:
         if not continue_on_error:


### PR DESCRIPTION
Closes #16

Just forgot to push the change `p.match_fun = eq_trials` before. Includes fixes for some stuff that got reverted in https://github.com/ktavabi/badbaby/pull/14/commits/4a1b62d1876a87c54bb18097046bc143b4c6a3d5 and introduced in https://github.com/ktavabi/badbaby/pull/14/commits/aa61d3dcd8f635289df12f43d6af4bd0c51b8b0c. With these changes I see:
```
Doing epoch EQ/DQ. 
  Loading raw files for subject bad_310b.
    Epoching data (decim=5 -> sfreq=360.0 Hz).
    Computing autoreject thresholds: grad=1208 fT/cm
    Events restricted to those in params.in_numbers
    Matching trial counts and saving data to disk.
      Analysis "All": 815 epochs / condition
      Equalizing: ['std', 'ba', 'wa']
      Analysis "Individual": 52 epochs / condition
      Equalizing with sub-condition matching: ['std', 'ba', 'wa']
      Analysis "Oddball": 104 epochs / condition
      Analysis "AM": 119 epochs / condition
      Analysis "IDs": 1 epochs / condition
    Saving epochs to disk.
  (0:00:43.050)
Done
```